### PR TITLE
Add standalone declaration because angular 19 defaults to standalone: true

### DIFF
--- a/src/inline-svg.component.ts
+++ b/src/inline-svg.component.ts
@@ -14,6 +14,7 @@ import { InlineSVGService } from './inline-svg.service';
 @Component({
   selector: 'inline-svg',
   template: '',
+  standalone: false,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class InlineSVGComponent implements AfterViewInit, OnChanges {

--- a/src/inline-svg.directive.ts
+++ b/src/inline-svg.directive.ts
@@ -27,7 +27,8 @@ import * as SvgUtil from './svg-util';
 
 @Directive({
   selector: '[inlineSVG]',
-  providers: [SVGCacheService]
+  providers: [SVGCacheService],
+  standalone: false
 })
 export class InlineSVGDirective implements OnInit, OnChanges, OnDestroy {
   @Input() inlineSVG: string;


### PR DESCRIPTION
Since Angular 19 defaults to standalone: true, the library doesn't work anymore. This PR should fix it.