### PR TITLE
Fix InlineSVGModule to use standalone components

### DIFF
--- a/src/inline-svg.module.ts
+++ b/src/inline-svg.module.ts
@@ -5,9 +5,8 @@ import { InlineSVGConfig } from './inline-svg.config';
 import { InlineSVGDirective } from './inline-svg.directive';
 
 @NgModule({
-  declarations: [InlineSVGDirective, InlineSVGComponent],
+  imports: [InlineSVGDirective, InlineSVGComponent],
   exports: [InlineSVGDirective],
-  entryComponents: [InlineSVGComponent]
 })
 export class InlineSVGModule {
   static forRoot(config?: InlineSVGConfig): ModuleWithProviders<InlineSVGModule> {


### PR DESCRIPTION
The component InlineSVGComponent  and the directive InlineSVGDirective  are now standalone, which requires changing some things in the module where they are used. They should no longer be declared in declarations but in imports.