### PR TITLE
Using angular partial compilationMode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ng-inline-svg-2",
-  "version": "19.0.0",
+  "version": "20.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ng-inline-svg-2",
-      "version": "19.0.0",
+      "version": "20.0.0",
       "license": "MIT",
       "devDependencies": {
         "@angular/common": "^14.0.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
   "angularCompilerOptions": {
     "decoratorsAs": "static fields",
     "skipTemplateCodegen": true,
-    "preserveWhitespaces": false
+    "preserveWhitespaces": false,
+    "compilationMode": "partial"
   }
 }


### PR DESCRIPTION
I changed the Ivy compilation type to partial as suggested in the angular documentation: https://angular.dev/tools/libraries/creating-libraries#ensuring-library-version-compatibility

This fixes an issue where in:
```   
// lib_esmodule/inline-svg.directive.js
};
    InlineSVGDirective.prototype._isSSRDisabled = function () {
        return isPlatformServer(this.platformId) && this._config && this._config.clientOnly;
    };
    InlineSVGDirective.ɵfac = function InlineSVGDirective_Factory(t) { return new (t || InlineSVGDirective)(i0.ɵɵdirectiveInject(i0.ElementRef), i0.ɵɵdirectiveInject(i0.ViewContainerRef), i0.ɵɵdirectiveInject(i0.ComponentFactoryResolver), i0.ɵɵdirectiveInject(i1.SVGCacheService), i0.ɵɵdirectiveInject(i0.Renderer2), i0.ɵɵdirectiveInject(i2.InlineSVGService), i0.ɵɵdirectiveInject(i3.InlineSVGConfig, 8), i0.ɵɵdirectiveInject(PLATFORM_ID)); };
    InlineSVGDirective.ɵdir = i0.ɵɵdefineDirective({ type: InlineSVGDirective, selectors: [["", "inlineSVG", ""]], inputs: { inlineSVG: "inlineSVG", resolveSVGUrl: "resolveSVGUrl", replaceContents: "replaceContents", prepend: "prepend", injectComponent: "injectComponent", cacheSVG: "cacheSVG", setSVGAttributes: "setSVGAttributes", removeSVGAttributes: "removeSVGAttributes", forceEvalStyles: "forceEvalStyles", evalScripts: "evalScripts", fallbackImgUrl: "fallbackImgUrl", fallbackSVG: "fallbackSVG", onSVGLoaded: "onSVGLoaded" }, outputs: { onSVGInserted: "onSVGInserted", onSVGFailed: "onSVGFailed" }, standalone: true, features: [i0.ɵɵProvidersFeature([SVGCacheService]), i0.ɵɵNgOnChangesFeature] });
    return InlineSVGDirective;
}());
export { InlineSVGDirective };
(function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(InlineSVGDirective, [{
        type: Directive,
        args: [{
```
`i0.ɵɵNgOnChangesFeature` would return undefined and cause applications to crash.